### PR TITLE
Make _filename and save non-enumerable

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -33,6 +33,16 @@ var db = function(filename, callback) {
 			});
 		};
 
+		// Make _filename and save non-enumerable so that they dont mess up data.length 
+		Object.defineProperties(data, {
+			'_filename': {
+				enumerable: false
+			},
+			'save': {
+				enumerable: false
+			}
+		});
+
 		callback(null, data);
 	});
 };


### PR DESCRIPTION
`_filename` and `save` mess up the `length` property of `data` since they are enumerable. This makes 'em non-enumerable.
