### PR TITLE
drop db._filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ flatfile [![Build Status](https://travis-ci.org/brendanashworth/flatfile.svg?bra
 $ npm i flatfile --save
 ```
 
+The module supports node v0.10, v0.12, and all major releases afterwards.
+
 ## Usage
-This example uses ES6 (see [io.js](https://iojs.org/en/index.html)), though the module is compatible up to node v0.10.
 ```javascript
 const flatfile = require('flatfile');
 
@@ -39,7 +40,7 @@ flatfile.db(filename, function(err, data))
 ```
 This is a very simple, asynchronous function for initiating the database. After reading the file and parsing to an object, it will return the object via the callback data paramater. If an error occurs while reading the file, it will be passed to the callback and *null* will be returned as data.
 
-**Warning**: the `data` object that is passed from this function is not an exact copy from the file, but can be treated as such. The data object is given two extra values: `_filename` and `save`. The `_filename` value is quite simple and simply stores the filename of the read database file. The `save` variable is a function that should be executed when the database should be saved.
+**Warning**: the `data` object that is passed from this function is not an exact copy from the file, but can be treated as such. The data object is given an extra value: `save`. `save` is a function that can be called when the database should be saved.
 
 ### Getting values
 ```javascript

--- a/src/db.js
+++ b/src/db.js
@@ -9,24 +9,16 @@ exports.db = function(filename, callback) {
 		// Parse data
 		data = JSON.parse(data);
 
-		// Adds various library-specific data handles
-		data._filename = filename;
-
 		// Adds the save function
 		data.save = function(callback) {
-			var filename = data._filename;
-
 			// Write to the file
 			fs.writeFile(filename, JSON.stringify(data), function(err) {
 				callback(err);
 			});
 		};
 
-		// Make _filename and save non-enumerable so that they dont mess up data.length
+		// Make `save` non-enumerable so that it doesn't mess up data.length
 		Object.defineProperties(data, {
-			'_filename': {
-				enumerable: false
-			},
 			'save': {
 				enumerable: false
 			}

--- a/test/database.js
+++ b/test/database.js
@@ -33,7 +33,6 @@ describe('flatfile database', function() {
 			main.db('./example/values.json', function(err, data) {
 				assert.isNull(err, 'should not have error');
 
-				assert.isString(data._filename);
 				assert.isFunction(data.save);
 
 				done();


### PR DESCRIPTION
This wasn't actually necessary, we can just use the closure in the code
already while eliminating a property on the file.

Semver: major?
