### PR TITLE
initiate new db on no-file open

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ flatfile.db('data.json', function(err, data) {
 ```javascript
 flatfile.db(filename, function(err, data))
 ```
-This is a very simple, asynchronous function for initiating the database. After reading the file and parsing to an object, it will return the object via the callback data paramater. If an error occurs while reading the file, it will be passed to the callback and *null* will be returned as data.
+This is a very simple, asynchronous function for initiating the database. After reading the file and parsing to an object, it will return the object via the callback data paramater. If the file does not exist, an empty object will be returned, allowing you to save it to a new file with `.save()`.
 
 **Warning**: the `data` object that is passed from this function is not an exact copy from the file, but can be treated as such. The data object is given an extra value: `save`. `save` is a function that can be called when the database should be saved.
 
@@ -58,7 +58,7 @@ Saving a file to the database is inherently easy. Simply reference and set the v
 ```javascript
 data.save(function(err));
 ```
-Again, this is a very simple function for saving the changes to the database. You can repetitively call this function without having an issue. As a paramater, this function takes a callback function with an error paramater. If an error did not occur, the error will not be defined. Otherwise, you can handle the error to your own delight.
+Again, this is a very simple function for saving the changes to the database. You can repetitively call this function without having an issue. As a paramater, this function takes a callback function with an error paramater.
 
 **Warning**: be aware that the data *will not automatically save*. It is necessary to call this function if you want to save the changes.
 

--- a/src/db.js
+++ b/src/db.js
@@ -3,8 +3,14 @@ var fs = require('fs');
 // This is the flatfile.db() function. It instantiates a local database asynchronously.
 exports.db = function(filename, callback) {
 	fs.readFile(filename, {encoding: 'utf8'}, function(err, data) {
-		if (err)
-			return callback(err, null);
+		if (err) {
+			// For errors besides does-not-exist, pass downstream.
+			if (err.code != 'ENOENT')
+				return callback(err, null);
+
+			// If it doesn't exist, return an empty object for instantiation.
+			data = '{}';
+		}
 
 		// Parse data
 		data = JSON.parse(data);


### PR DESCRIPTION
When `flatfile.db` is called on a file that does not exist, we should
create a new object and return it rather than returning an error.

This allows the user to create a new database file with `flatfile.db`
without having to explicitly create it and populate it beforehand.

This is a semver-major change; `before this`, flatfile.db would give an
ENOENT error when called on a file that does not exist.

Semver: major
Fixes: https://github.com/brendanashworth/flatfile/issues/2
